### PR TITLE
Fix misinterpreted call to getBudget()

### DIFF
--- a/vk_mem_alloc.hpp
+++ b/vk_mem_alloc.hpp
@@ -369,7 +369,7 @@ namespace VMA_HPP_NAMESPACE {
 
     void getBudget( Budget* pBudget ) const;
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
-    Budget getBudget() const;
+    std::vector<Budget> getBudget() const;
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
 #ifdef VULKAN_HPP_DISABLE_ENHANCED_MODE
@@ -2363,11 +2363,14 @@ namespace VMA_HPP_NAMESPACE {
     ::vmaGetBudget( m_allocator, reinterpret_cast<VmaBudget*>( pBudget ) );
   }
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
-  VULKAN_HPP_INLINE Budget Allocator::getBudget() const
+  VULKAN_HPP_INLINE std::vector<Budget> Allocator::getBudget() const
   {
-    Budget budget;
-    ::vmaGetBudget( m_allocator, reinterpret_cast<VmaBudget*>( &budget ) );
-    return budget;
+    const VkPhysicalDeviceMemoryProperties* pPhysicalDeviceMemoryProperties = nullptr;
+    vmaGetMemoryProperties(m_allocator, &pPhysicalDeviceMemoryProperties);
+
+    std::vector<Budget> budgets(pPhysicalDeviceMemoryProperties->memoryHeapCount);
+    ::vmaGetBudget( m_allocator, reinterpret_cast<VmaBudget*>( budgets.data(); ) );
+    return budgets;
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 


### PR DESCRIPTION
vmaGetBudget() does not, in fact, take a single VmaBudget as an out parameter. Instead, it expects that to be an array of size `memoryHeapCount`.

I will be submitting an issue to VMA proper about this as well, since before switching to VMA-HPP I made the same incorrect assumption, so I think the function is poorly named.

In any event, this will correctly call vmaGetBudget(), by creating a vector of the correct size and then returning that.

Without it you get this lovely stack corruption error, and at least on Visual Studio 2019, a full-on segfault.